### PR TITLE
Fixed log rotation issues

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -107,10 +107,14 @@ TURNKEY_CREDIT="<div id='turnkey-credit'> <div> <a href='http://www.turnkeylinux
 FOOTER=$WEBROOT/app/views/layouts/base.html.erb
 sed -i "s|</body>|$TURNKEY_CREDIT\n</body>|" $FOOTER
 
+# setup logs for rotation
+rm -r $WEBROOT/log
+ln -s /var/log/redmine/ $WEBROOT/log
+
 # configure permissions
 chown -R root:www-data $WEBROOT
 chown -R www-data:www-data $WEBROOT/tmp
-chown -R www-data:www-data $WEBROOT/log
+chown -R www-data:www-data /var/log/redmine/
 chown -R www-data:www-data $WEBROOT/files
 
 mkdir -p $WEBROOT/public/plugin_assets


### PR DESCRIPTION
replaced /var/www/redmine/log/ with a symlink pointing to
/var/log/redmine as per rotatelog config (/etc/rotatelog.d/redmine)

Has not been tested on a production server but when forced to rotate with verbose output, it seems to work as expected without issues.

This should close https://github.com/turnkeylinux/tracker/issues/373
