### PR TITLE
fix readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ Core`_, and on top of that:
 
 - SSL support out of the box.
 - Includes Phusion Passenger for Apache web server (mod_rails).
-- Uses Ruby Enterprise (performance).
 - Postfix MTA (bound to localhost) to allow sending of email (e.g.,
   password recovery).
 - Webmin modules for configuring Apache2, MySQL and Postfix.


### PR DESCRIPTION
- remove mention of Ruby Enterprise - part of turnkeylinux/tracker#632
