### PR TITLE
Update to current stable 

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,6 +4,19 @@ turnkey-redmine-14.1 (1) turnkey; urgency=low
 
   * Upstream source component versions:
 
+    redmine         3.2.6
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Wed, 21 Jun 2017 10:50:13 +0300
+
+turnkey-redmine-14.1 (1) turnkey; urgency=low
+
+  * Upgraded to latest stable version of Redmine.
+
+  * Upstream source component versions:
+
     redmine         3.2.0
 
   * Note: Please refer to turnkey-core's changelog for changes common to all

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION=3.2.0
+VERSION=3.2.6
 SRC="/usr/local/src"
 dl http://www.redmine.org/releases/redmine-${VERSION}.tar.gz $SRC
 dl http://www.redmine.org/releases/redmine-${VERSION}.tar.gz.md5 $SRC


### PR DESCRIPTION
  Redmine version                3.2.6.stable
  Ruby version                   2.3.3-p222 (2016-11-21) [x86_64-linux]
  Rails version                  4.2.7.1
