### PR TITLE
Rename ruby env var RBY_VER -> RUBY_VER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 3690 4155 8080 9418 12320 12321
 
-RBY_VER=3.2
+RUBY_VER=3.2
 
 include $(FAB_PATH)/common/mk/turnkey/revisioncontrol.mk
 include $(FAB_PATH)/common/mk/turnkey/rails.mk


### PR DESCRIPTION
As per subject: Rename ruby env var `RBY_VER` -> `RUBY_VER`

Also requires:
- https://github.com/turnkeylinux/common/pull/298